### PR TITLE
read Mapbox credentials at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,14 @@
-# To use this Dockerfile, run the following:
-#
-# docker build --build-arg MAPBOX_ACCESS_TOKEN="$MAPBOX_ACCESS_TOKEN" \
-#              --build-arg MAPBOX_STYLE="$MAPBOX_STYLE" \
-#              --tag rideshare-viz .
-#
-# docker run -p 8080:80 rideshare-viz
+# docker build --tag rideshare-viz .
+# docker run -d -p 8080:80 -e MAPBOX_ACCESS_TOKEN="$MAPBOX_ACCESS_TOKEN" -e MAPBOX_STYLE="$MAPBOX_STYLE" rideshare-viz
 
 FROM node:10.16-alpine AS builder
 WORKDIR /build
 COPY . ./
-ARG MAPBOX_ACCESS_TOKEN
-ARG MAPBOX_STYLE=mapbox://styles/mapbox/light-v9
-ENV MAPBOX_ACCESS_TOKEN=$MAPBOX_ACCESS_TOKEN
-ENV MAPBOX_STYLE=$MAPBOX_STYLE
 RUN npm run build:ci
 
 FROM nginx:1.17.3-alpine
 COPY --from=builder /build/dist /usr/share/nginx/html
+COPY ./scripts/docker-startup.sh /startup.sh 
+RUN chmod +x /startup.sh
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT ["/startup.sh", "/usr/share/nginx/html"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export MAPBOX_STYLE=mapbox://styles/foo # optional; will default to mapbox://sty
 After cloning this repository and configuring your environment, run:
 
 ```Shell
-npm ci  # install dependencies
+npm install  # install dependencies
 npm start  # start development server on localhost:8080
 ```
 
@@ -51,8 +51,8 @@ This repository contains a `Dockerfile` that builds an image of the static site,
 After cloning this repository and configuring your environment, run the following commands. Note that `--build-arg MAPBOX_STYLE="$MAPBOX_STYLE"` is optional and will default to [Mapbox Light](https://www.mapbox.com/maps/light-dark/). Docker will not read the build args from a `.env` file, so they must be provided as environment variables or directly specified in the command.
 
 ```Shell
-docker build --build-arg MAPBOX_ACCESS_TOKEN="$MAPBOX_ACCESS_TOKEN" --build-arg MAPBOX_STYLE="$MAPBOX_STYLE" --tag rideshare-viz . # build image
-docker run -p 8080:80 rideshare-viz # start project on localhost:8080
+docker build --tag rideshare-viz . # build image
+docker run -d -p 8080:80 -e MAPBOX_ACCESS_TOKEN="$MAPBOX_ACCESS_TOKEN" -e MAPBOX_STYLE="$MAPBOX_STYLE" rideshare-viz # start project on localhost:8080
 ```
 
 Once the container is running, the demo is accessible on [localhost:8080](http://localhost:8080).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4709,6 +4709,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "generate-json-webpack-plugin": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/generate-json-webpack-plugin/-/generate-json-webpack-plugin-0.3.1.tgz",
+      "integrity": "sha512-0gsqCyLf1OF+9tjN75QkPYV6UoyuPCfhgLXcX44/Ft9j82z9kBG/7yMS/ufN8yU2l4noSNEVNYQ9GdqenH/0cQ==",
+      "dev": true
+    },
     "geojson-rbush": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-react": "~7.14.3",
     "eslint-plugin-react-hooks": "~1.6.1",
     "file-loader": "~4.2.0",
+    "generate-json-webpack-plugin": "~0.3.1",
     "html-webpack-plugin": "~3.2.0",
     "mini-css-extract-plugin": "~0.8.0",
     "optimize-css-assets-webpack-plugin": "~5.0.3",

--- a/scripts/docker-startup.sh
+++ b/scripts/docker-startup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+[ -z "$MAPBOX_ACCESS_TOKEN" ] && echo "MAPBOX_ACCESS_TOKEN must be supplied via the -e flag. Exiting." && exit 1
+template='{"MAPBOX_ACCESS_TOKEN":"%s","MAPBOX_STYLE":"%s"}'
+config_file=$(printf "$template" "$MAPBOX_ACCESS_TOKEN" "$MAPBOX_STYLE")
+echo "$config_file" > $1/config.json
+nginx -g 'daemon off;'

--- a/src/js/actions/index.js
+++ b/src/js/actions/index.js
@@ -4,6 +4,28 @@ import { getBufferFiles, getUnloadedBufferFiles, getNextFramePosition } from 'se
 
 let simulationTimer;
 
+export const INITIALIZE_APP_REQUEST = 'INITIALIZE_APP_REQUEST';
+export const initializeAppRequest = () => ({
+  type: INITIALIZE_APP_REQUEST
+});
+
+export const INITIALIZE_APP_SUCCESS = 'INITIALIZE_APP_SUCCESS';
+export const initializeAppSuccess = () => ({
+  type: INITIALIZE_APP_SUCCESS
+});
+
+export const INITIALIZE_APP_FAILURE = 'INITIALIZE_APP_FAILURE';
+export const initializeAppFailure = (error = 'App could not be initialized.') => ({
+  type: INITIALIZE_APP_FAILURE,
+  error
+});
+
+export const LOAD_CONFIG_SUCCESS = 'LOAD_CONFIG_SUCCESS';
+export const loadConfigSuccess = (config = {}) => ({
+  type: LOAD_CONFIG_SUCCESS,
+  config
+});
+
 export const CHOOSE_FILES_SUCCESS = 'CHOOSE_FILES_SUCCESS';
 export const chooseFilesSuccess = (files = []) => ({
   type: CHOOSE_FILES_SUCCESS,
@@ -71,6 +93,20 @@ export const DESELECT_DRIVER = 'DESELECT_DRIVER';
 export const deselectDriver = () => ({
   type: DESELECT_DRIVER
 });
+
+export const initializeApp = () => {
+  return async dispatch => {
+    dispatch(initializeAppRequest());
+    try {
+      const response = await fetch('config.json');
+      const config = await response.json();
+      dispatch(loadConfigSuccess(config));
+      dispatch(initializeAppSuccess());
+    } catch (err) {
+      dispatch(initializeAppFailure(err.message || err.toString()));
+    }
+  };
+};
 
 export const chooseFilesAndPlaySimulation = fileList => {
   const files = [...fileList];

--- a/src/js/components/App/App.jsx
+++ b/src/js/components/App/App.jsx
@@ -1,11 +1,15 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import DriverDetails from 'containers/DriverDetails';
 import Map from 'containers/Map';
 import PlaybackControls from 'containers/PlaybackControls';
 import Welcome from 'containers/Welcome';
 
-const App = ({ loaded = false }) => {
+const App = ({ initialized = false, loaded = false, onInitialize }) => {
+  useEffect(() => onInitialize(), [onInitialize]);
+
+  if (!initialized) return null;
+
   return (
     <React.Fragment>
       {!loaded && <Welcome />}
@@ -17,7 +21,9 @@ const App = ({ loaded = false }) => {
 };
 
 App.propTypes = {
-  loaded: PropTypes.bool
+  initialized: PropTypes.bool,
+  loaded: PropTypes.bool,
+  onInitialize: PropTypes.func.isRequired
 };
 
 export default App;

--- a/src/js/components/Map/Map.jsx
+++ b/src/js/components/Map/Map.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import MapLoading from './MapLoading';
@@ -27,12 +27,12 @@ const MAP_STYLES = {
   COLOR_SELECTED: '#343a40'
 };
 
-function Map({ buffered, fileGeojson, frameGeojson, loaded, selectedDriverId, selectDriver }) {
+function Map({ buffered, config = {}, fileGeojson, frameGeojson, loaded, selectedDriverId, selectDriver }) {
   const [map, setMap] = useState(null);
   const [mapLoaded, setMapLoaded] = useState(false);
   const [hoveredDriverId, setHoveredDriverId] = useState(null);
 
-  useInitializeMap({ setMap, setMapLoaded, setHoveredDriverId, selectDriver, MAP_ID, MAP_STYLES });
+  useInitializeMap({ config, setMap, setMapLoaded, setHoveredDriverId, selectDriver, MAP_ID, MAP_STYLES });
   useUpdateMapFileGeojson({ map, mapLoaded, fileGeojson, selectedDriverId, hoveredDriverId });
   useUpdateMapFrameGeojson({ map, mapLoaded, frameGeojson, selectedDriverId, hoveredDriverId });
   useUpdateMapSelectedDriver({ map, mapLoaded, selectedDriverId, hoveredDriverId });
@@ -47,6 +47,7 @@ function Map({ buffered, fileGeojson, frameGeojson, loaded, selectedDriverId, se
 
 Map.propTypes = {
   buffered: PropTypes.bool.isRequired,
+  config: PropTypes.object,
   fileGeojson: PropTypes.object,
   frameGeojson: PropTypes.object,
   loaded: PropTypes.bool.isRequired,

--- a/src/js/components/Map/hooks/use-initialize-map.js
+++ b/src/js/components/Map/hooks/use-initialize-map.js
@@ -1,14 +1,14 @@
 import { useEffect } from 'react';
 import mapboxgl from 'mapbox-gl';
-import { MAPBOX_ACCESS_TOKEN, MAPBOX_STYLE } from 'utils/constants';
 
 const geojsonPlaceholder = {
   type: 'FeatureCollection',
   features: []
 };
 
-function useInitializeMap({ setMap, setMapLoaded, setHoveredDriverId, selectDriver, MAP_ID, MAP_STYLES }) {
+function useInitializeMap({ config, setMap, setMapLoaded, setHoveredDriverId, selectDriver, MAP_ID, MAP_STYLES }) {
   useEffect(() => {
+    const { MAPBOX_ACCESS_TOKEN, MAPBOX_STYLE } = config;
     const { MAP_DEFAULT_CENTER, MAP_DEFAULT_ZOOM, COLOR_ASSIGNED, COLOR_UNASSIGNED, COLOR_SELECTED } = MAP_STYLES;
     mapboxgl.accessToken = MAPBOX_ACCESS_TOKEN;
 
@@ -16,7 +16,7 @@ function useInitializeMap({ setMap, setMapLoaded, setHoveredDriverId, selectDriv
       container: MAP_ID,
       center: MAP_DEFAULT_CENTER,
       zoom: MAP_DEFAULT_ZOOM,
-      style: MAPBOX_STYLE
+      style: MAPBOX_STYLE || 'mapbox://styles/mapbox/light-v9'
     });
 
     const popup = new mapboxgl.Popup({
@@ -188,7 +188,7 @@ function useInitializeMap({ setMap, setMapLoaded, setHoveredDriverId, selectDriv
     map.on('click', 'driver-points', onClick);
 
     setMap(map);
-  }, [setMap, setMapLoaded, setHoveredDriverId, selectDriver, MAP_ID, MAP_STYLES]);
+  }, [setMap, setMapLoaded, setHoveredDriverId, selectDriver, MAP_ID, MAP_STYLES, config]);
 }
 
 export default useInitializeMap;

--- a/src/js/containers/App/App.js
+++ b/src/js/containers/App/App.js
@@ -1,10 +1,19 @@
 import { connect } from 'react-redux';
+import { initializeApp } from 'actions';
 import App from 'components/App';
 
 const mapStateToProps = ({ status }) => {
-  return {
-    loaded: status.loaded
-  };
+  const { initialized, loaded } = status;
+  return { initialized, loaded };
 };
 
-export default connect(mapStateToProps)(App);
+const mapDispatchToProps = dispatch => ({
+  onInitialize: () => {
+    dispatch(initializeApp());
+  }
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(App);

--- a/src/js/containers/Map/Map.js
+++ b/src/js/containers/Map/Map.js
@@ -11,6 +11,7 @@ const mapStateToProps = state => {
 
   return {
     buffered,
+    config: state.config,
     loaded,
     fileGeojson: currentFile ? currentFile.geojson : null,
     frameGeojson: currentFrame ? currentFrame.geojson : null,

--- a/src/js/reducers/config.factory.js
+++ b/src/js/reducers/config.factory.js
@@ -1,0 +1,6 @@
+const createState = ({ MAPBOX_ACCESS_TOKEN = null, MAPBOX_STYLE = null } = {}) => ({
+  MAPBOX_ACCESS_TOKEN,
+  MAPBOX_STYLE
+});
+
+export default createState;

--- a/src/js/reducers/config.js
+++ b/src/js/reducers/config.js
@@ -1,0 +1,20 @@
+import { LOAD_CONFIG_SUCCESS } from 'actions';
+
+const initialState = {
+  MAPBOX_ACCESS_TOKEN: null,
+  MAPBOX_STYLE: null
+};
+
+export default function config(state = initialState, action = {}) {
+  switch (action.type) {
+    case LOAD_CONFIG_SUCCESS: {
+      return {
+        ...state,
+        ...action.config
+      };
+    }
+
+    default:
+      return state;
+  }
+}

--- a/src/js/reducers/config.test.js
+++ b/src/js/reducers/config.test.js
@@ -1,0 +1,25 @@
+import test from 'tape';
+import reducer from 'reducers/config';
+import createState from 'reducers/config.factory';
+import { LOAD_CONFIG_SUCCESS } from 'actions';
+
+test('configReducer() with no arguments', ({ same, end }) => {
+  const msg = 'should return correct state';
+
+  const actual = reducer();
+  const expected = createState();
+
+  same(actual, expected, msg);
+  end();
+});
+
+test(`configReducer() with action ${LOAD_CONFIG_SUCCESS}`, ({ same, end }) => {
+  const msg = 'should return correct state';
+
+  const config = { MAPBOX_ACCESS_TOKEN: 'foo', MAPBOX_STYLE: 'bar ' };
+  const actual = reducer({}, { type: LOAD_CONFIG_SUCCESS, config });
+  const expected = createState(config);
+
+  same(actual, expected, msg);
+  end();
+});

--- a/src/js/reducers/index.js
+++ b/src/js/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
+import config from './config';
 import driver from './driver';
 import files from './files';
 import status from './status';
 
-export default combineReducers({ driver, files, status });
+export default combineReducers({ config, driver, files, status });

--- a/src/js/reducers/status.factory.js
+++ b/src/js/reducers/status.factory.js
@@ -1,5 +1,13 @@
-const createState = ({ buffered = false, loading = false, loaded = false, error = null, playing = false } = {}) => ({
+const createState = ({
+  buffered = false,
+  initialized = false,
+  loading = false,
+  loaded = false,
+  error = null,
+  playing = false
+} = {}) => ({
   buffered,
+  initialized,
   loading,
   loaded,
   error,

--- a/src/js/reducers/status.js
+++ b/src/js/reducers/status.js
@@ -1,4 +1,5 @@
 import {
+  INITIALIZE_APP_SUCCESS,
   LOAD_FILES_REQUEST,
   LOAD_FILES_SUCCESS,
   LOAD_FILES_FAILURE,
@@ -10,6 +11,7 @@ import {
 
 const initialState = {
   buffered: false,
+  initialized: false,
   loading: false,
   loaded: false,
   error: null,
@@ -18,6 +20,15 @@ const initialState = {
 
 export default function status(state = initialState, action = {}) {
   switch (action.type) {
+    case INITIALIZE_APP_SUCCESS: {
+      return {
+        ...state,
+        ...{
+          initialized: true
+        }
+      };
+    }
+
     case LOAD_FILES_REQUEST: {
       return {
         ...state,

--- a/src/js/reducers/status.test.js
+++ b/src/js/reducers/status.test.js
@@ -2,6 +2,7 @@ import test from 'tape';
 import reducer from 'reducers/status';
 import createState from 'reducers/status.factory';
 import {
+  INITIALIZE_APP_SUCCESS,
   LOAD_FILES_REQUEST,
   LOAD_FILES_SUCCESS,
   LOAD_FILES_FAILURE,
@@ -10,6 +11,16 @@ import {
   STOP_SIMULATION,
   BUFFER_SIMULATION
 } from 'actions';
+
+test(`statusReducer() with action ${INITIALIZE_APP_SUCCESS}`, ({ same, end }) => {
+  const msg = 'should return correct state';
+
+  const actual = reducer(undefined, { type: INITIALIZE_APP_SUCCESS });
+  const expected = createState({ initialized: true });
+
+  same(actual, expected, msg);
+  end();
+});
 
 test('statusReducer() with no arguments', ({ same, end }) => {
   const msg = 'should return correct state';

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -1,7 +1,5 @@
 export const FILES_PER_SECOND = 1;
 export const FRAMERATE = 30;
 export const FRAMES_PER_FILE = Math.ceil(FRAMERATE / FILES_PER_SECOND);
-export const MAPBOX_ACCESS_TOKEN = process.env.MAPBOX_ACCESS_TOKEN;
-export const MAPBOX_STYLE = process.env.MAPBOX_STYLE || 'mapbox://styles/mapbox/light-v9';
 export const SECONDS_TO_BUFFER = 5;
 export const SECONDS_TO_SKIP = 2;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,14 +1,9 @@
 const path = require('path');
-const webpack = require('webpack');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const GenerateJsonPlugin = require('generate-json-webpack-plugin');
 require('dotenv').config();
-
-if (!process.env.MAPBOX_ACCESS_TOKEN) {
-  console.error('Missing required environment variable MAPBOX_ACCESS_TOKEN.');
-  process.exit(1);
-}
 
 module.exports = {
   entry: {
@@ -42,9 +37,9 @@ module.exports = {
       title: 'rideshare viz',
       template: 'src/js/templates/index.html'
     }),
-    new webpack.DefinePlugin({
-      'process.env.MAPBOX_ACCESS_TOKEN': JSON.stringify(process.env.MAPBOX_ACCESS_TOKEN),
-      'process.env.MAPBOX_STYLE': JSON.stringify(process.env.MAPBOX_STYLE)
+    new GenerateJsonPlugin('config.json', {
+      MAPBOX_ACCESS_TOKEN: process.env.MAPBOX_ACCESS_TOKEN,
+      MAPBOX_STYLE: process.env.MAPBOX_STYLE
     })
   ],
   resolve: {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,6 +1,11 @@
 const merge = require('webpack-merge');
 const common = require('./webpack.common.js');
 
+if (!process.env.MAPBOX_ACCESS_TOKEN) {
+  console.error('Missing required environment variable MAPBOX_ACCESS_TOKEN.');
+  process.exit(1);
+}
+
 module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',


### PR DESCRIPTION
Fixes issue #4.

### Why
Mapbox credentials were being read from the environment as part of the build process, which meant that build artifacts could only be used for a single environment.

### What
This PR updates the React app to load Mapbox credentials from a `config.json` file at the site root. Webpack will generate this file as part of the site build process, and it can also be overwritten if starting up the site with `docker run`.