### PR TITLE
[#11] fixes Safari bug

### DIFF
--- a/src/js/components/Welcome/WelcomeFileInput.jsx
+++ b/src/js/components/Welcome/WelcomeFileInput.jsx
@@ -20,7 +20,7 @@ function WelcomeFileInput({ loadFiles }) {
         hidden
         aria-hidden="true"
         tabIndex="-1"
-        onInput={() => loadFiles(document.getElementById(inputID).files)}
+        onChange={() => loadFiles(document.getElementById(inputID).files)}
       />
       <StyledButton onClick={() => document.getElementById(inputID).click()}>Browse</StyledButton>
     </React.Fragment>


### PR DESCRIPTION
Fixes #11.

### Steps to repro

Using the latest Safari, attempt to upload simulation files. The user can select files but then nothing happens.

### Cause

Safari doesn't support the `onInput` event. See https://caniuse.com/#feat=input-event.

### Solution

Changed the `onInput` event to `onChange`, which is supported.
